### PR TITLE
A button and A door simple back-end without visuals

### DIFF
--- a/Godot_project/_not_for_export/test_door_and_button_interactive/main_test_level_door_and_button_1.gd
+++ b/Godot_project/_not_for_export/test_door_and_button_interactive/main_test_level_door_and_button_1.gd
@@ -1,0 +1,7 @@
+extends Node2D
+
+const SETTINGS_UI = preload("res://scenes/settings/settings_ui.tscn")
+
+func _physics_process(delta: float) -> void:
+	if(Input.is_action_just_pressed("ui_cancel")):
+		get_tree().current_scene.add_child(SETTINGS_UI.instantiate())

--- a/Godot_project/_not_for_export/test_door_and_button_interactive/main_test_level_door_and_button_1.gd.uid
+++ b/Godot_project/_not_for_export/test_door_and_button_interactive/main_test_level_door_and_button_1.gd.uid
@@ -1,0 +1,1 @@
+uid://c86ebdqnoalgu

--- a/Godot_project/_not_for_export/test_door_and_button_interactive/main_test_level_door_and_button_1.tscn
+++ b/Godot_project/_not_for_export/test_door_and_button_interactive/main_test_level_door_and_button_1.tscn
@@ -1,0 +1,115 @@
+[gd_scene load_steps=10 format=3 uid="uid://bsv107sor8kuc"]
+
+[ext_resource type="Script" uid="uid://c86ebdqnoalgu" path="res://_not_for_export/test_door_and_button_interactive/main_test_level_door_and_button_1.gd" id="1_1uofp"]
+[ext_resource type="Script" uid="uid://cyf6hcvtn0lac" path="res://_not_for_export/test_door_and_button_interactive/test_character.gd" id="1_cmgnq"]
+[ext_resource type="Script" uid="uid://38e8upkqw3kr" path="res://_not_for_export/test_door_and_button_interactive/test_button_label.gd" id="2_1uofp"]
+[ext_resource type="Script" uid="uid://dejophbfm3k03" path="res://_not_for_export/test_door_and_button_interactive/test_door_label.gd" id="3_unlr7"]
+[ext_resource type="PackedScene" uid="uid://dfqjxthp6ml5d" path="res://scenes/interactive_objects/interactive_button.tscn" id="4_yak0a"]
+[ext_resource type="PackedScene" uid="uid://b76212mcar6o2" path="res://scenes/interactive_objects/interactive_door.tscn" id="5_5gglj"]
+
+[sub_resource type="CapsuleShape2D" id="CapsuleShape2D_86svo"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_kuogi"]
+size = Vector2(23.5102, 35.2703)
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_44g3h"]
+
+[node name="TestLevelDoorAndButton" type="Node2D"]
+script = ExtResource("1_1uofp")
+
+[node name="CharacterBody2D" type="CharacterBody2D" parent="."]
+position = Vector2(157, 537)
+scale = Vector2(3.0625, 3.82759)
+collision_mask = 34
+script = ExtResource("1_cmgnq")
+
+[node name="Label" type="Label" parent="CharacterBody2D"]
+offset_left = -15.3469
+offset_top = -12.2793
+offset_right = 75.6531
+offset_bottom = 8.72072
+scale = Vector2(0.32574, 0.408581)
+text = "Test Player"
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="CharacterBody2D"]
+shape = SubResource("CapsuleShape2D_86svo")
+
+[node name="InteractionArea" type="Area2D" parent="CharacterBody2D"]
+unique_name_in_owner = true
+collision_layer = 0
+collision_mask = 32
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="CharacterBody2D/InteractionArea"]
+position = Vector2(0, -0.391891)
+shape = SubResource("RectangleShape2D_kuogi")
+debug_color = Color(0.761275, 0.451523, 1.15514e-06, 0.42)
+
+[node name="Env" type="Node2D" parent="."]
+
+[node name="Floor" type="StaticBody2D" parent="Env"]
+position = Vector2(576, 628)
+scale = Vector2(56.6031, 1.72039)
+collision_layer = 2
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Env/Floor"]
+shape = SubResource("RectangleShape2D_44g3h")
+
+[node name="Wall" type="StaticBody2D" parent="Env"]
+position = Vector2(71, 380)
+rotation = 1.5708
+scale = Vector2(56.6031, 1.72039)
+collision_layer = 2
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Env/Wall"]
+shape = SubResource("RectangleShape2D_44g3h")
+
+[node name="Wall2" type="StaticBody2D" parent="Env"]
+position = Vector2(1085, 486)
+rotation = 1.5708
+scale = Vector2(56.6031, 1.72039)
+collision_layer = 2
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Env/Wall2"]
+shape = SubResource("RectangleShape2D_44g3h")
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+
+[node name="Camera2D" type="Camera2D" parent="."]
+position = Vector2(576, 377)
+
+[node name="ButtonLabel" type="Label" parent="."]
+offset_left = 884.0
+offset_top = 418.0
+offset_right = 1021.0
+offset_bottom = 439.0
+text = "Button is inactive"
+script = ExtResource("2_1uofp")
+
+[node name="DoorLabel" type="Label" parent="."]
+offset_left = 223.0
+offset_top = 465.0
+offset_right = 328.0
+offset_bottom = 486.0
+text = "Door is closed"
+script = ExtResource("3_unlr7")
+
+[node name="Label" type="Label" parent="."]
+offset_left = 324.0
+offset_top = 156.0
+offset_right = 385.0
+offset_bottom = 177.0
+scale = Vector2(8.00337, 8.36421)
+theme_override_colors/font_color = Color(1, 0, 0, 1)
+text = "LEVEL 1"
+
+[node name="TestingSubjects" type="Node" parent="."]
+
+[node name="Button" parent="TestingSubjects" node_paths=PackedStringArray("door") instance=ExtResource("4_yak0a")]
+unique_name_in_owner = true
+position = Vector2(951, 525)
+door = NodePath("../InteractiveDoor")
+
+[node name="InteractiveDoor" parent="TestingSubjects" instance=ExtResource("5_5gglj")]
+unique_name_in_owner = true
+position = Vector2(270, 552)
+level_to_load = "uid://c3kdj24in5ucf"

--- a/Godot_project/_not_for_export/test_door_and_button_interactive/test_button_label.gd
+++ b/Godot_project/_not_for_export/test_door_and_button_interactive/test_button_label.gd
@@ -1,0 +1,9 @@
+## It is not in-production code!
+extends Label
+@onready var _button: InteractiveButton = %Button
+
+func _physics_process(_delta: float) -> void:
+	if(_button._button_timer.is_stopped()):
+		self.text = "Button is inactive"
+	else:
+		self.text = "Button is active"

--- a/Godot_project/_not_for_export/test_door_and_button_interactive/test_button_label.gd.uid
+++ b/Godot_project/_not_for_export/test_door_and_button_interactive/test_button_label.gd.uid
@@ -1,0 +1,1 @@
+uid://38e8upkqw3kr

--- a/Godot_project/_not_for_export/test_door_and_button_interactive/test_character.gd
+++ b/Godot_project/_not_for_export/test_door_and_button_interactive/test_character.gd
@@ -1,0 +1,24 @@
+## It is not in-production code!
+extends CharacterBody2D
+
+@onready var _interaction_area: Area2D = %InteractionArea
+
+func _ready() -> void:
+	_interaction_area.area_entered.connect(_on_area_entered)
+
+func _physics_process(_delta: float) -> void:
+	var direction: Vector2 = Input.get_vector("ui_left", "ui_right", "ui_up", "ui_down")
+	velocity = direction * 25000.0 * _delta
+	move_and_slide()
+	if(Input.is_action_just_pressed("interact")):
+		_try_to_activate_button()
+
+func _try_to_activate_button() -> void:
+	for i: Area2D in _interaction_area.get_overlapping_areas():
+		if(i is InteractiveButton):
+			(i as InteractiveButton).activate_button()
+
+func _on_area_entered(area: Area2D) -> void:
+	if(area is InteractiveDoor):
+		SceneManager.load_scene((area as InteractiveDoor).level_to_load)
+		

--- a/Godot_project/_not_for_export/test_door_and_button_interactive/test_character.gd.uid
+++ b/Godot_project/_not_for_export/test_door_and_button_interactive/test_character.gd.uid
@@ -1,0 +1,1 @@
+uid://cyf6hcvtn0lac

--- a/Godot_project/_not_for_export/test_door_and_button_interactive/test_door_label.gd
+++ b/Godot_project/_not_for_export/test_door_and_button_interactive/test_door_label.gd
@@ -1,0 +1,10 @@
+## It is not in-production code!
+extends Label
+
+@onready var _interactive_door: InteractiveDoor = %InteractiveDoor
+
+func _physics_process(_delta: float) -> void:
+	if(_interactive_door.monitorable == true):
+		self.text = "Door is opened"
+	else:
+		self.text = "Door is closed"

--- a/Godot_project/_not_for_export/test_door_and_button_interactive/test_door_label.gd.uid
+++ b/Godot_project/_not_for_export/test_door_and_button_interactive/test_door_label.gd.uid
@@ -1,0 +1,1 @@
+uid://dejophbfm3k03

--- a/Godot_project/_not_for_export/test_door_and_button_interactive/test_level_door_and_button_2.tscn
+++ b/Godot_project/_not_for_export/test_door_and_button_interactive/test_level_door_and_button_2.tscn
@@ -1,0 +1,115 @@
+[gd_scene load_steps=10 format=3 uid="uid://c3kdj24in5ucf"]
+
+[ext_resource type="Script" uid="uid://c86ebdqnoalgu" path="res://_not_for_export/test_door_and_button_interactive/main_test_level_door_and_button_1.gd" id="1_b6p1e"]
+[ext_resource type="Script" uid="uid://cyf6hcvtn0lac" path="res://_not_for_export/test_door_and_button_interactive/test_character.gd" id="1_wc1qe"]
+[ext_resource type="Script" uid="uid://38e8upkqw3kr" path="res://_not_for_export/test_door_and_button_interactive/test_button_label.gd" id="2_avhca"]
+[ext_resource type="Script" uid="uid://dejophbfm3k03" path="res://_not_for_export/test_door_and_button_interactive/test_door_label.gd" id="3_b6p1e"]
+[ext_resource type="PackedScene" uid="uid://dfqjxthp6ml5d" path="res://scenes/interactive_objects/interactive_button.tscn" id="4_yf64p"]
+[ext_resource type="PackedScene" uid="uid://b76212mcar6o2" path="res://scenes/interactive_objects/interactive_door.tscn" id="5_ktrs5"]
+
+[sub_resource type="CapsuleShape2D" id="CapsuleShape2D_86svo"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_kuogi"]
+size = Vector2(23.5102, 35.2703)
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_44g3h"]
+
+[node name="TestLevelDoorAndButton" type="Node2D"]
+script = ExtResource("1_b6p1e")
+
+[node name="CharacterBody2D" type="CharacterBody2D" parent="."]
+position = Vector2(157, 537)
+scale = Vector2(3.0625, 3.82759)
+collision_mask = 2
+script = ExtResource("1_wc1qe")
+
+[node name="Label" type="Label" parent="CharacterBody2D"]
+offset_left = -15.3469
+offset_top = -12.2793
+offset_right = 75.6531
+offset_bottom = 8.72072
+scale = Vector2(0.32574, 0.408581)
+text = "Test Player"
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="CharacterBody2D"]
+shape = SubResource("CapsuleShape2D_86svo")
+
+[node name="InteractionArea" type="Area2D" parent="CharacterBody2D"]
+unique_name_in_owner = true
+collision_layer = 0
+collision_mask = 32
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="CharacterBody2D/InteractionArea"]
+position = Vector2(0, -0.391891)
+shape = SubResource("RectangleShape2D_kuogi")
+debug_color = Color(0.761275, 0.451523, 1.15514e-06, 0.42)
+
+[node name="Env" type="Node2D" parent="."]
+
+[node name="Floor" type="StaticBody2D" parent="Env"]
+position = Vector2(576, 628)
+scale = Vector2(56.6031, 1.72039)
+collision_layer = 2
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Env/Floor"]
+shape = SubResource("RectangleShape2D_44g3h")
+
+[node name="Wall" type="StaticBody2D" parent="Env"]
+position = Vector2(71, 380)
+rotation = 1.5708
+scale = Vector2(56.6031, 1.72039)
+collision_layer = 2
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Env/Wall"]
+shape = SubResource("RectangleShape2D_44g3h")
+
+[node name="Wall2" type="StaticBody2D" parent="Env"]
+position = Vector2(1085, 486)
+rotation = 1.5708
+scale = Vector2(56.6031, 1.72039)
+collision_layer = 2
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Env/Wall2"]
+shape = SubResource("RectangleShape2D_44g3h")
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+
+[node name="Camera2D" type="Camera2D" parent="."]
+position = Vector2(576, 377)
+
+[node name="ButtonLabel" type="Label" parent="."]
+offset_left = 884.0
+offset_top = 418.0
+offset_right = 1021.0
+offset_bottom = 439.0
+text = "Button is inactive"
+script = ExtResource("2_avhca")
+
+[node name="DoorLabel" type="Label" parent="."]
+offset_left = 222.0
+offset_top = 476.0
+offset_right = 327.0
+offset_bottom = 497.0
+text = "door is closed"
+script = ExtResource("3_b6p1e")
+
+[node name="Label" type="Label" parent="."]
+offset_left = 338.0
+offset_top = 137.0
+offset_right = 408.0
+offset_bottom = 158.0
+scale = Vector2(6.87838, 6.21424)
+theme_override_colors/font_color = Color(0, 0, 1, 1)
+text = "LEVEL 2"
+
+[node name="TestingSubjects" type="Node" parent="."]
+
+[node name="Button" parent="TestingSubjects" node_paths=PackedStringArray("door") instance=ExtResource("4_yf64p")]
+unique_name_in_owner = true
+position = Vector2(951, 525)
+door = NodePath("../InteractiveDoor")
+
+[node name="InteractiveDoor" parent="TestingSubjects" instance=ExtResource("5_ktrs5")]
+unique_name_in_owner = true
+position = Vector2(270, 552)
+level_to_load = "uid://bsv107sor8kuc"

--- a/Godot_project/globals/scripts/scene_manager.gd
+++ b/Godot_project/globals/scripts/scene_manager.gd
@@ -16,12 +16,13 @@ func _start_load_scene()-> void:
 		return
 	loading_screen = _loading_screen_scene.instantiate() as LoadingScreen
 	get_tree().root.add_child(loading_screen)
+	loading_screen.start_transition()
 	if(!loading_screen.transition_in_ended.is_connected(_on_transition_in_ended)):
 		if loading_screen.transition_in_ended.connect(_on_transition_in_ended): printerr("Fail: ",get_path()) 
 	
 func _end_load_scene()-> void:
 	@warning_ignore("return_value_discarded")
-	get_tree().change_scene_to_packed(_load_scene)
+	await get_tree().change_scene_to_packed(_load_scene)
 	transition_finished.emit()
 	await loading_screen.finish_transition()
 	get_tree().root.remove_child(loading_screen)

--- a/Godot_project/project.godot
+++ b/Godot_project/project.godot
@@ -57,21 +57,6 @@ theme/default_font_generate_mipmaps=true
 
 [input]
 
-sds={
-"deadzone": 0.2,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":59,"key_label":0,"unicode":59,"location":0,"echo":false,"script":null)
-]
-}
-zzz={
-"deadzone": 0.2,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":100,"location":0,"echo":false,"script":null)
-]
-}
-keker={
-"deadzone": 0.2,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":115,"location":0,"echo":false,"script":null)
-]
-}
 limbo_console_toggle={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":81,"physical_keycode":0,"key_label":0,"unicode":81,"location":0,"echo":false,"script":null)
@@ -87,12 +72,21 @@ limbo_console_search_history={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":true,"meta_pressed":false,"pressed":false,"keycode":82,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
+interact={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":69,"key_label":0,"unicode":101,"location":0,"echo":false,"script":null)
+]
+}
 
 [internationalization]
 
 locale/translation_remaps={}
 locale/translations=PackedStringArray("res://assets/localizations/translation_template.en.translation", "res://assets/localizations/translation_template.ru.translation", "res://assets/localizations/translation_template.nm.translation", "res://assets/localizations/translation_template.nml.translation")
 locale/translations_pot_files=PackedStringArray("res://scenes/settings/settings_ui.tscn", "res://scenes/settings/setting_windows/controls_settings_ui.tscn", "res://scenes/settings/setting_windows/game_settings_ui.tscn", "res://scenes/settings/setting_windows/graphic_settings_ui.tscn", "res://scenes/settings/setting_windows/sound_settings_ui.tscn")
+
+[layer_names]
+
+2d_physics/layer_6="button and door"
 
 [rendering]
 

--- a/Godot_project/scenes/interactive_objects/interactive_button.gd
+++ b/Godot_project/scenes/interactive_objects/interactive_button.gd
@@ -1,0 +1,31 @@
+class_name InteractiveButton
+extends Area2D
+
+@export_range(0.0,100.0) var time_of_active_state: float = 5.0
+@export var door: InteractiveDoor
+
+@onready var _button_timer: Timer = %ButtonTimer
+@onready var _click_button_sound: AudioStreamPlayer = %ClickButtonSound
+
+
+func _ready() -> void:
+	add_to_group("InteractiveButton")
+	_init_interactive_button()
+	_connect_signals()
+
+func _init_interactive_button() -> void:
+	if(door == null):
+		printerr("Button does not have a door to reference to")
+	_button_timer.wait_time = time_of_active_state
+
+func _connect_signals() -> void:
+	_button_timer.timeout.connect(_on_button_timer_timeout)
+
+func activate_button() -> void:
+	if(_button_timer.is_stopped()):
+		door.open()
+		_button_timer.start()
+
+##AKA deactivate_button
+func _on_button_timer_timeout() -> void:
+	door.close()

--- a/Godot_project/scenes/interactive_objects/interactive_button.gd.uid
+++ b/Godot_project/scenes/interactive_objects/interactive_button.gd.uid
@@ -1,0 +1,1 @@
+uid://cgboh61ucwdsd

--- a/Godot_project/scenes/interactive_objects/interactive_button.tscn
+++ b/Godot_project/scenes/interactive_objects/interactive_button.tscn
@@ -1,0 +1,23 @@
+[gd_scene load_steps=3 format=3 uid="uid://dfqjxthp6ml5d"]
+
+[ext_resource type="Script" uid="uid://cgboh61ucwdsd" path="res://scenes/interactive_objects/interactive_button.gd" id="1_wry5t"]
+
+[sub_resource type="CircleShape2D" id="CircleShape2D_ey4g0"]
+radius = 78.0
+
+[node name="InteractiveButton" type="Area2D"]
+collision_layer = 32
+collision_mask = 0
+script = ExtResource("1_wry5t")
+
+[node name="ButtonCollisionShape" type="CollisionShape2D" parent="."]
+shape = SubResource("CircleShape2D_ey4g0")
+debug_color = Color(0.794663, 0.425313, 1.92523e-07, 0.42)
+
+[node name="ButtonTimer" type="Timer" parent="."]
+unique_name_in_owner = true
+one_shot = true
+
+[node name="ClickButtonSound" type="AudioStreamPlayer" parent="."]
+unique_name_in_owner = true
+bus = &"SFX"

--- a/Godot_project/scenes/interactive_objects/interactive_door.gd
+++ b/Godot_project/scenes/interactive_objects/interactive_door.gd
@@ -1,0 +1,14 @@
+class_name InteractiveDoor
+extends Area2D
+
+@export var level_to_load: String
+
+func _ready() -> void:
+	if(level_to_load == null):
+		printerr("Interactive door has not a level to transit to")
+
+func open() -> void:
+	self.monitorable = true
+
+func close() -> void:
+	self.monitorable = false

--- a/Godot_project/scenes/interactive_objects/interactive_door.gd.uid
+++ b/Godot_project/scenes/interactive_objects/interactive_door.gd.uid
@@ -1,0 +1,1 @@
+uid://5gli5mwbygij

--- a/Godot_project/scenes/interactive_objects/interactive_door.tscn
+++ b/Godot_project/scenes/interactive_objects/interactive_door.tscn
@@ -1,0 +1,17 @@
+[gd_scene load_steps=3 format=3 uid="uid://b76212mcar6o2"]
+
+[ext_resource type="Script" uid="uid://5gli5mwbygij" path="res://scenes/interactive_objects/interactive_door.gd" id="1_a2c6x"]
+
+[sub_resource type="CapsuleShape2D" id="CapsuleShape2D_jagx2"]
+radius = 36.0
+height = 100.0
+
+[node name="InteractiveDoor" type="Area2D"]
+collision_layer = 32
+collision_mask = 0
+monitorable = false
+script = ExtResource("1_a2c6x")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("CapsuleShape2D_jagx2")
+debug_color = Color(0.796078, 0.423529, 0, 0.419608)

--- a/Godot_project/scenes/utility/loading_screen.tscn
+++ b/Godot_project/scenes/utility/loading_screen.tscn
@@ -1,21 +1,6 @@
-[gd_scene load_steps=6 format=3 uid="uid://c2bqi4xuffjwt"]
+[gd_scene load_steps=5 format=3 uid="uid://c2bqi4xuffjwt"]
 
 [ext_resource type="Script" uid="uid://dotlhu4d65b2k" path="res://scenes/utility/loading_screen.gd" id="1_tk0ri"]
-
-[sub_resource type="Animation" id="Animation_mn4ff"]
-length = 0.001
-tracks/0/type = "value"
-tracks/0/imported = false
-tracks/0/enabled = true
-tracks/0/path = NodePath("BackGround:color")
-tracks/0/interp = 1
-tracks/0/loop_wrap = true
-tracks/0/keys = {
-"times": PackedFloat32Array(0),
-"transitions": PackedFloat32Array(1),
-"update": 0,
-"values": [Color(1, 1, 1, 1)]
-}
 
 [sub_resource type="Animation" id="Animation_66jto"]
 resource_name = "fade_to_black"
@@ -51,12 +36,12 @@ tracks/0/keys = {
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_qsleh"]
 _data = {
-&"RESET": SubResource("Animation_mn4ff"),
 &"fade_to_black": SubResource("Animation_66jto"),
 &"fade_to_normal": SubResource("Animation_xs08y")
 }
 
 [node name="LoadingScreen" type="CanvasLayer"]
+process_mode = 3
 script = ExtResource("1_tk0ri")
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
@@ -67,5 +52,9 @@ libraries = {
 
 [node name="BackGround" type="ColorRect" parent="."]
 unique_name_in_owner = true
-offset_right = 40.0
-offset_bottom = 40.0
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(1, 1, 1, 0)


### PR DESCRIPTION
Fix SceneManager bug. Now It does work.
Add button and door scenes. Plyaer.tscn will have interacting area. So player will call buttons' method (activate button) and take UID for next level from door. _(See object UML Diagram screenshot)_
![image](https://github.com/user-attachments/assets/7c324760-bdf3-4d79-bddd-6a46e495c293)

In order to test this feature you may play res://_not_for_export/test_door_and_button_interactive/main_test_level_door_and_button_1.tscn scene.


In order to set up level you must put a button scene and a door scene and you must provide an UID to door node. Door node has export string variable which represents PackedScene UID.