### PR TITLE
Platform is disappearning as soon as sonar is gone

### DIFF
--- a/Godot_project/scenes/interactive_objects/emerging_platform.gd
+++ b/Godot_project/scenes/interactive_objects/emerging_platform.gd
@@ -10,6 +10,7 @@ extends StaticBody2D
 @onready var platform_stays: AudioStreamPlayer2D = %platformStays
 @onready var plat_texture: Sprite2D = %platTexture
 @onready var _cpu_particles_2d: CPUParticles2D = %CPUParticles2D
+@onready var light_over: PointLight2D = %lightOver
 
 
 var _emit_to_platform_verti_distances: Array
@@ -30,6 +31,7 @@ func _ready() -> void:
 func _init_platform() -> void:
 	plat_texture.self_modulate.a = 0
 	collision_shape.disabled = 1
+	light_over.enabled = 0
 	_cpu_particles_2d.emitting = false
 	
 func _connect_signals() -> void:
@@ -108,6 +110,7 @@ func _emerge() -> void:
 	collision_shape.disabled = 0
 	plat_texture.self_modulate.a = 1.0
 	_cpu_particles_2d.emitting = true
+	light_over.enabled = 1
 	if _seen_timer.is_stopped():
 		_seen_timer.start()
 		
@@ -126,6 +129,8 @@ func _disappear() -> void:
 	_emerged_sound = false
 	_emerge_success_sonar = false
 	_cpu_particles_2d.emitting = false
+	await get_tree().create_timer(1.0).timeout
+	light_over.enabled = 0
 
 func _timer_stopped() -> void:
 	_disappear()

--- a/Godot_project/scenes/interactive_objects/emerging_platform.gd
+++ b/Godot_project/scenes/interactive_objects/emerging_platform.gd
@@ -10,7 +10,7 @@ extends StaticBody2D
 @onready var platform_stays: AudioStreamPlayer2D = %platformStays
 @onready var plat_texture: Sprite2D = %platTexture
 @onready var _cpu_particles_2d: CPUParticles2D = %CPUParticles2D
-@onready var light_over: PointLight2D = %lightOver
+
 
 
 var _emit_to_platform_verti_distances: Array
@@ -31,7 +31,6 @@ func _ready() -> void:
 func _init_platform() -> void:
 	plat_texture.self_modulate.a = 0
 	collision_shape.disabled = 1
-	light_over.enabled = 0
 	_cpu_particles_2d.emitting = false
 	
 func _connect_signals() -> void:
@@ -110,7 +109,6 @@ func _emerge() -> void:
 	collision_shape.disabled = 0
 	plat_texture.self_modulate.a = 1.0
 	_cpu_particles_2d.emitting = true
-	light_over.enabled = 1
 	if _seen_timer.is_stopped():
 		_seen_timer.start()
 		
@@ -130,7 +128,6 @@ func _disappear() -> void:
 	_emerge_success_sonar = false
 	_cpu_particles_2d.emitting = false
 	await get_tree().create_timer(1.0).timeout
-	light_over.enabled = 0
 
 func _timer_stopped() -> void:
 	_disappear()

--- a/Godot_project/scenes/interactive_objects/emerging_platform.tscn
+++ b/Godot_project/scenes/interactive_objects/emerging_platform.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=11 format=3 uid="uid://d0d8qlhogli8h"]
+[gd_scene load_steps=10 format=3 uid="uid://d0d8qlhogli8h"]
 
 [ext_resource type="Script" uid="uid://bcrv2wq7qm5b2" path="res://scenes/interactive_objects/emerging_platform.gd" id="1_0xh5m"]
 [ext_resource type="AudioStream" uid="uid://cunsri3qbw3o1" path="res://assets/sounds/emerging_platform/PlatEmergy.wav" id="2_6irwq"]
 [ext_resource type="AudioStream" uid="uid://dq1ytkk18cfmx" path="res://assets/sounds/emerging_platform/PlatActivated.wav" id="3_i27d1"]
 [ext_resource type="AudioStream" uid="uid://chpq8ukdd0v2s" path="res://assets/sounds/emerging_platform/PlatDisappearing.wav" id="4_756po"]
+[ext_resource type="Material" uid="uid://dseapks3kvvhm" path="res://assets/materials/no_light_unshaded.tres" id="5_i27d1"]
 
 [sub_resource type="CanvasItemMaterial" id="CanvasItemMaterial_6irwq"]
 light_mode = 1
@@ -17,13 +18,6 @@ gradient = SubResource("Gradient_6irwq")
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_ss2rw"]
 size = Vector2(64, 64)
-
-[sub_resource type="Gradient" id="Gradient_i27d1"]
-offsets = PackedFloat32Array(1)
-colors = PackedColorArray(1, 1, 1, 1)
-
-[sub_resource type="GradientTexture2D" id="GradientTexture2D_756po"]
-gradient = SubResource("Gradient_i27d1")
 
 [node name="EmergingPlatform" type="StaticBody2D"]
 collision_layer = 2
@@ -62,6 +56,7 @@ stream = ExtResource("4_756po")
 [node name="CPUParticles2D" type="CPUParticles2D" parent="."]
 unique_name_in_owner = true
 modulate = Color(1, 0.8075, 0.45, 1)
+material = ExtResource("5_i27d1")
 amount = 1000
 emission_shape = 3
 emission_rect_extents = Vector2(32, 32)
@@ -72,10 +67,3 @@ radial_accel_min = -4.0
 radial_accel_max = 2.0
 scale_amount_min = 2.0
 scale_amount_max = 2.0
-
-[node name="lightOver" type="PointLight2D" parent="."]
-unique_name_in_owner = true
-position = Vector2(0, -0.5)
-scale = Vector2(1, 0.984375)
-energy = 3.0
-texture = SubResource("GradientTexture2D_756po")

--- a/Godot_project/scenes/interactive_objects/emerging_platform.tscn
+++ b/Godot_project/scenes/interactive_objects/emerging_platform.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=3 uid="uid://d0d8qlhogli8h"]
+[gd_scene load_steps=11 format=3 uid="uid://d0d8qlhogli8h"]
 
 [ext_resource type="Script" uid="uid://bcrv2wq7qm5b2" path="res://scenes/interactive_objects/emerging_platform.gd" id="1_0xh5m"]
 [ext_resource type="AudioStream" uid="uid://cunsri3qbw3o1" path="res://assets/sounds/emerging_platform/PlatEmergy.wav" id="2_6irwq"]
@@ -17,6 +17,13 @@ gradient = SubResource("Gradient_6irwq")
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_ss2rw"]
 size = Vector2(64, 64)
+
+[sub_resource type="Gradient" id="Gradient_i27d1"]
+offsets = PackedFloat32Array(1)
+colors = PackedColorArray(1, 1, 1, 1)
+
+[sub_resource type="GradientTexture2D" id="GradientTexture2D_756po"]
+gradient = SubResource("Gradient_i27d1")
 
 [node name="EmergingPlatform" type="StaticBody2D"]
 collision_layer = 2
@@ -55,7 +62,7 @@ stream = ExtResource("4_756po")
 [node name="CPUParticles2D" type="CPUParticles2D" parent="."]
 unique_name_in_owner = true
 modulate = Color(1, 0.8075, 0.45, 1)
-amount = 40
+amount = 1000
 emission_shape = 3
 emission_rect_extents = Vector2(32, 32)
 gravity = Vector2(0, 0)
@@ -63,4 +70,12 @@ angular_velocity_min = 532.6
 angular_velocity_max = 532.6
 radial_accel_min = -4.0
 radial_accel_max = 2.0
-scale_amount_max = 3.0
+scale_amount_min = 2.0
+scale_amount_max = 2.0
+
+[node name="lightOver" type="PointLight2D" parent="."]
+unique_name_in_owner = true
+position = Vector2(0, -0.5)
+scale = Vector2(1, 0.984375)
+energy = 3.0
+texture = SubResource("GradientTexture2D_756po")

--- a/Godot_project/scenes/player/player.tscn
+++ b/Godot_project/scenes/player/player.tscn
@@ -220,7 +220,6 @@ script = ExtResource("1_7obkq")
 
 [node name="playerSprite" type="AnimatedSprite2D" parent="."]
 unique_name_in_owner = true
-visible = false
 scale = Vector2(0.128386, 0.133241)
 sprite_frames = SubResource("SpriteFrames_0y4ya")
 animation = &"fall"


### PR DESCRIPTION
When the platform is out of sonar it disappears.

Added a point2d Light node as it draws over canvas items. 
Enabled and disabled the point2d light as per the platform visibility calculations.